### PR TITLE
fix: correct groupId for common-util dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -173,7 +173,7 @@
         </dependency>
 
         <dependency>
-            <groupId>org.igot</groupId>
+            <groupId>net.karmayogibharat</groupId>
             <artifactId>common-util</artifactId>
             <version>1.0.3</version>
         </dependency>


### PR DESCRIPTION
Change groupId from org.igot to net.karmayogibharat for common-util:1.0.3. The artifact is not published to Maven Central under org.igot, causing Docker build failures. net.karmayogibharat is the correct groupId used across other services (cb-ext-userprofile-service).