### PR TITLE
KB-11618 | BE| TECHDEBT| JUnit test cases to improve the code coverage for the custom-fields service

### DIFF
--- a/src/main/java/com/igot/cb/customFields/service/impl/CustomFieldsServiceImpl.java
+++ b/src/main/java/com/igot/cb/customFields/service/impl/CustomFieldsServiceImpl.java
@@ -110,7 +110,7 @@ public class CustomFieldsServiceImpl implements CustomFieldsService {
 
             // Store in Redis cache
             JsonNode responseNode = objectMapper.valueToTree(customFieldMap);
-            cacheService.putCache("CUSTOM_FIELD_" + customFieldId, responseNode);
+            cacheService.putCache(Constants.CUSTOM_FIELD + customFieldId, responseNode);
 
             // Set success response
             response.setResponseCode(HttpStatus.OK);
@@ -154,7 +154,7 @@ public class CustomFieldsServiceImpl implements CustomFieldsService {
             Optional<CustomFieldEntity> customFieldOpt = customFieldRepository.findByCustomFiledIdAndIsActiveTrue(customFieldId);
             if (customFieldOpt.isEmpty()) {
                 response.getParams().setStatus(Constants.FAILED);
-                response.getParams().setErrMsg("Custom field not found with ID: " + customFieldId);
+                response.getParams().setErrMsg(Constants.CUSTOM_FIELD_NOT_FOUND + customFieldId);
                 response.setResponseCode(HttpStatus.NOT_FOUND);
                 return response;
             }
@@ -165,7 +165,7 @@ public class CustomFieldsServiceImpl implements CustomFieldsService {
             customFieldMap.put(Constants.CUSTOM_FIELD_ID, customFieldId);
 
             // Cache result for future requests
-            cacheService.putCache("CUSTOM_FIELD_" + customFieldId, customFieldMap);
+            cacheService.putCache(Constants.CUSTOM_FIELD + customFieldId, customFieldMap);
 
             response.setResponseCode(HttpStatus.OK);
             response.setMessage(Constants.SUCCESS);
@@ -272,7 +272,7 @@ public class CustomFieldsServiceImpl implements CustomFieldsService {
 
             // Update Redis cache
             JsonNode responseNode = objectMapper.valueToTree(customFieldMap);
-            cacheService.putCache("CUSTOM_FIELD_" + customFieldId, responseNode);
+            cacheService.putCache(Constants.CUSTOM_FIELD + customFieldId, responseNode);
             response.setResponseCode(HttpStatus.OK);
             response.setMessage(Constants.SUCCESS);
             response.setResult(customFieldMap);
@@ -299,7 +299,7 @@ public class CustomFieldsServiceImpl implements CustomFieldsService {
 
             Optional<CustomFieldEntity> customFieldOpt = customFieldRepository.findByCustomFiledIdAndIsActiveTrue(customFieldId);
             if (customFieldOpt.isEmpty()) {
-                ProjectUtil.returnErrorMsg("Custom field not found with ID: " + customFieldId, HttpStatus.NOT_FOUND, response, Constants.FAILED);
+                ProjectUtil.returnErrorMsg(Constants.CUSTOM_FIELD_NOT_FOUND + customFieldId, HttpStatus.NOT_FOUND, response, Constants.FAILED);
                 return response;
             }
 
@@ -345,7 +345,7 @@ public class CustomFieldsServiceImpl implements CustomFieldsService {
                     cbServerProperties.getCustomFieldElasticMappingJsonPath()
             );
 
-            cacheService.deleteCache("CUSTOM_FIELD_" + customFieldId);
+            cacheService.deleteCache(Constants.CUSTOM_FIELD + customFieldId);
             log.info("Cache and ES entries updated for deleted custom field: {}", customFieldId);
 
             response.setResponseCode(HttpStatus.OK);
@@ -724,7 +724,7 @@ public class CustomFieldsServiceImpl implements CustomFieldsService {
                     payloadNode.get(Constants.CUSTOM_FIELD_ID).asText()
             );
             if (customFieldOpt.isEmpty()) {
-                ProjectUtil.returnErrorMsg("Custom field not found with ID: " + payloadNode.get(Constants.CUSTOM_FIELD_ID).asText(), HttpStatus.NOT_FOUND, response, Constants.FAILED);
+                ProjectUtil.returnErrorMsg(Constants.CUSTOM_FIELD_NOT_FOUND + payloadNode.get(Constants.CUSTOM_FIELD_ID).asText(), HttpStatus.NOT_FOUND, response, Constants.FAILED);
                 return response;
             }
 
@@ -943,7 +943,7 @@ public class CustomFieldsServiceImpl implements CustomFieldsService {
 
             Optional<CustomFieldEntity> customFieldOpt = customFieldRepository.findByCustomFiledIdAndIsActiveTrue(customFieldId);
             if (customFieldOpt.isEmpty()) {
-                ProjectUtil.returnErrorMsg("Custom field not found with ID: " + customFieldId, HttpStatus.NOT_FOUND, response, Constants.FAILED);
+                ProjectUtil.returnErrorMsg(Constants.CUSTOM_FIELD_NOT_FOUND + customFieldId, HttpStatus.NOT_FOUND, response, Constants.FAILED);
                 return response;
             }
 

--- a/src/main/java/com/igot/cb/pores/elasticsearch/dto/SearchResult.java
+++ b/src/main/java/com/igot/cb/pores/elasticsearch/dto/SearchResult.java
@@ -16,7 +16,7 @@ import java.util.Map;
 @NoArgsConstructor
 public class SearchResult implements Serializable {
 
-  private List<Map<String, Object>> data;
+  private transient List<Map<String, Object>> data;
   private Map<String, List<FacetDTO>> facets;
   private long totalCount;
 }

--- a/src/main/java/com/igot/cb/pores/elasticsearch/service/EsUtilServiceImpl.java
+++ b/src/main/java/com/igot/cb/pores/elasticsearch/service/EsUtilServiceImpl.java
@@ -269,6 +269,8 @@ public class EsUtilServiceImpl implements EsUtilService {
                                         case Constants.SEARCH_OPERATION_LESS_THAN:
                                             rangeQuery.lt((JsonData) rangeValue);
                                             break;
+                                        default:
+                                            log.info(Constants.UNSUPPORTED_RANGE + rangeOperator);
                                     }
                                 });
                                 rangeOrNullQuery.should(rangeQuery.build()._toQuery());

--- a/src/main/java/com/igot/cb/pores/util/Constants.java
+++ b/src/main/java/com/igot/cb/pores/util/Constants.java
@@ -119,6 +119,9 @@ public class Constants {
     public static final String CUSTOM_FIELD_UPDATE_VALIDATION_FILE_PATH = "/payloadValidation/customFieldUpdateValidation.json";
     public static final String NAME = "name";
     public static final String CUSTOM_FIELD_FILTER_ATTRIBUTE = "originalCustomFieldData.attributeName";
+    public static final String CUSTOM_FIELD_NOT_FOUND = "Custom field not found with ID: ";
+    public static final String LOCAL_DATACENTER = "datacenter1";
+
     private Constants() {
     }
 }

--- a/src/main/java/com/igot/cb/transactional/cassandrautils/CassandraConnectionManagerImpl.java
+++ b/src/main/java/com/igot/cb/transactional/cassandrautils/CassandraConnectionManagerImpl.java
@@ -93,7 +93,7 @@ public class CassandraConnectionManagerImpl implements CassandraConnectionManage
             DriverConfigLoader loader = DriverConfigLoader.programmaticBuilder()
                     .withStringList(DefaultDriverOption.CONTACT_POINTS, contactPointsString)
                     .withString(DefaultDriverOption.REQUEST_CONSISTENCY, consistencyLevelName)
-                    .withString(DefaultDriverOption.LOAD_BALANCING_LOCAL_DATACENTER, "datacenter1")
+                    .withString(DefaultDriverOption.LOAD_BALANCING_LOCAL_DATACENTER, Constants.LOCAL_DATACENTER)
                     .withInt(DefaultDriverOption.CONNECTION_POOL_LOCAL_SIZE,
                             Integer.parseInt(cache.getProperty(Constants.CORE_CONNECTIONS_PER_HOST_FOR_LOCAL)))
                     .withInt(DefaultDriverOption.CONNECTION_POOL_REMOTE_SIZE,
@@ -110,14 +110,14 @@ public class CassandraConnectionManagerImpl implements CassandraConnectionManage
             if (StringUtils.isNotBlank(keySpaceName)) {
                 sessionWithKeyspaces = CqlSession.builder()
                         .addContactPoints(contactPoints)
-                        .withLocalDatacenter("datacenter1")
+                        .withLocalDatacenter(Constants.LOCAL_DATACENTER)
                         .withKeyspace(keySpaceName)
                         .withConfigLoader(loader)
                         .build();
             } else {
                 sessionWithKeyspaces = CqlSession.builder()
                         .addContactPoints(contactPoints)
-                        .withLocalDatacenter("datacenter1")
+                        .withLocalDatacenter(Constants.LOCAL_DATACENTER)
                         .withConfigLoader(loader)
                         .build();
             }

--- a/src/test/java/com/igot/cb/customFields/service/impl/CustomFieldsServiceImplTest.java
+++ b/src/test/java/com/igot/cb/customFields/service/impl/CustomFieldsServiceImplTest.java
@@ -207,7 +207,7 @@ class CustomFieldsServiceImplTest {
         assertNotNull(response.getResult());
         assertEquals(customFieldMap.get("name"), ((Map<?, ?>) response.getResult()).get("name"));
 
-        verify(cacheService).putCache(eq("CUSTOM_FIELD_" + customFieldId), any());
+        verify(cacheService).putCache(eq(Constants.CUSTOM_FIELD + customFieldId), any());
     }
 
     @Test


### PR DESCRIPTION

- Extract hardcoded strings into Constants:
    - "CUSTOM_FIELD_" → Constants.CUSTOM_FIELD (cache key prefix)
    - "Custom field not found with ID: " → Constants.CUSTOM_FIELD_NOT_FOUND
    - "datacenter1" → Constants.LOCAL_DATACENTER
- Add default case to range query switch in EsUtilServiceImpl to handle unsupported operators gracefully
- Mark SearchResult.data field as transient to suppress serialization Sonar warning